### PR TITLE
Modified settings file

### DIFF
--- a/content/usr/local/etc/nzbget/nzbget.conf
+++ b/content/usr/local/etc/nzbget/nzbget.conf
@@ -64,6 +64,7 @@ DumpCore=no
 LoadPars=one
 ParCheck=no
 ParRepair=yes
+ParScan=limited
 StrictParName=yes
 ParTimeLimit=0
 ParPauseQueue=no


### PR DESCRIPTION
The ParScan setting should be set to limited (auto is default) to avoid crashes when the non patched libpar2-0 is used. Ideally libpar2-0 could be compiled with the patches applied and included. 
